### PR TITLE
Add DiskManagementSettings DDM declaration to block external storage

### DIFF
--- a/lib/macos/declaration-profiles/disk-management-settings-ddm.json
+++ b/lib/macos/declaration-profiles/disk-management-settings-ddm.json
@@ -1,0 +1,9 @@
+{
+    "Type": "com.apple.configuration.diskmanagement.settings",
+    "Identifier": "d1a2b3c4-e5f6-7890-abcd-ef1234567890",
+    "Payload": {
+        "Restrictions": {
+            "ExternalStorage": "Disallowed"
+        }
+    }
+}

--- a/teams/workstations.yml
+++ b/teams/workstations.yml
@@ -6,6 +6,7 @@ controls:
   macos_settings:
     custom_settings:
       - path: ../lib/macos/declaration-profiles/passcode-settings-ddm.json
+      - path: ../lib/macos/declaration-profiles/disk-management-settings-ddm.json
 software:
 team_settings:
   secrets:


### PR DESCRIPTION
Add a DiskManagementSettings DDM declaration profile that sets ExternalStorage to Disallowed for macOS hosts in the Workstations team.

Closes #9

Generated with [Claude Code](https://claude.ai/code)